### PR TITLE
Make possible to install on other platforms than windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,10 @@ function removeUsedLetters(usedLetters) {
 }
 
 function letters() {
+  if (!isWinOs()) {
+    throw (new Error('windows-drive-letters can only run on windows.'));
+  }
+
   return new Promise((resolve, reject) => {
     childProcess.exec(command, (err, stdout) => {
       if (err) {
@@ -33,6 +37,10 @@ function letters() {
 module.exports.letters = letters;
 
 function usedLetters() {
+  if (!isWinOs()) {
+    throw (new Error('windows-drive-letters can only run on windows.'));
+  }
+
   return new Promise((resolve, reject) => {
     childProcess.exec(command, (err, stdout) => {
       if (err) {
@@ -64,6 +72,10 @@ function randomLetter() {
 module.exports.randomLetter = randomLetter;
 
 function usedLettersSync() {
+  if (!isWinOs()) {
+    throw (new Error('windows-drive-letters can only run on windows.'));
+  }
+
   const stdout = childProcess.execSync(command);
   const letters = tableParser.parse(stdout.toString()).map((caption) => {
     return caption.Caption[0].replace(':', '');
@@ -75,6 +87,10 @@ function usedLettersSync() {
 module.exports.usedLettersSync = usedLettersSync;
 
 function lettersSync() {
+  if (!isWinOs()) {
+    throw (new Error('windows-drive-letters can only run on windows.'));
+  }
+
   const stdout = childProcess.execSync(command);
   const letters = tableParser.parse(stdout.toString()).map((caption) => {
     return caption.Caption[0].replace(':', '');
@@ -92,3 +108,7 @@ function randomLetterSync() {
 }
 
 module.exports.randomLetterSync = randomLetterSync;
+
+function isWinOs() {
+  return /^win/.test(process.platform);
+}

--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
   "engines": {
     "node": ">=4.0.0"
   },
-  "os": [
-    "win32"
-  ],
   "scripts": {
     "test": "xo && mocha --timeout=5000"
   },


### PR DESCRIPTION
Hi

I am using this package as part of a multiplatform project, but it is not possible to install this package on OSX without removing the constraint in `package.json`. Could it be better to throw errors in the code when code that is not supported for the platform is run? That would at least make it possible to have this installed as a dependency when developing on a platform other that windows.

Thanks.

